### PR TITLE
Added parameters to set the height and width of the flag and changed help shorthand to "?"

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const { name, version } = require('../package.json')
 const { randNum, interpolateColor, FlagColors, ArgParser } = require('./util')
 
 const cliOptions = {
-    help: { type: 'boolean', short: 'h', description: 'Display this help text' },
+    help: { type: 'boolean', short: '?', description: 'Display this help text' },
     gradient: {
         type: 'boolean',
         short: 'g',
@@ -44,6 +44,18 @@ const cliOptions = {
         type: 'boolean',
         short: 'r',
         description: 'Displays a random flag! This ignores any passed flags.',
+    },
+    height: {
+        type: 'string',
+        short: 'h',
+        description: 'The height of the flag, in characters. May not generate the exact specified height',
+        argName: 'int',
+    },
+    width: {
+        type: 'string',
+        short: 'w',
+        description: 'The width of the flag, in characters',
+        argName: 'int',
     },
     'install-completion': {
         type: 'boolean',
@@ -191,6 +203,9 @@ function createFlag(availableWidth, availableHeight, options) {
             }
             finishedFlag += chalk.hex(color)(CHAR)
         }
+        if (options.width) {
+            finishedFlag += '\n'
+        }
         return finishedFlag.repeat(availableHeight)
     }
 
@@ -204,7 +219,7 @@ function createFlag(availableWidth, availableHeight, options) {
             const color2 = blendColors.getColor(position, options.gradient ? 'gradient' : null)
             color = interpolateColor(color, color2, blendFactor)
         }
-        finishedFlag += chalk.hex(color)(CHAR.repeat(availableWidth))
+        finishedFlag += chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width ? '\n' : '')
         currLine++
     }
     return finishedFlag
@@ -216,8 +231,8 @@ function draw() {
         process.stdout.write('\x1b[0;0f\x1b[2J\x1b[?25l')
     }
     try {
-        const availableHeight = process.stdout.rows
-        const availableWidth = process.stdout.columns
+        const availableHeight = options.height ? options.height : process.stdout.rows
+        const availableWidth = options.width ? options.width : process.stdout.columns
         const builtFlag = createFlag(availableWidth, availableHeight, options)
         process.stdout.write(builtFlag)
     } catch (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -206,7 +206,7 @@ function createFlag(availableWidth, availableHeight, options) {
         if (options.width) {
             finishedFlag += '\n'
         }
-        return finishedFlag.repeat(availableHeight)
+        return finishedFlag.repeat(availableHeight).trim()
     }
 
     // clearly its not a vertical flag, proceed with horizontal
@@ -222,7 +222,7 @@ function createFlag(availableWidth, availableHeight, options) {
         finishedFlag += chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width ? '\n' : '')
         currLine++
     }
-    return finishedFlag
+    return finishedFlag.trim()
 }
 
 function draw() {
@@ -233,6 +233,7 @@ function draw() {
     try {
         const availableHeight = options.height ? options.height : process.stdout.rows
         const availableWidth = options.width ? options.width : process.stdout.columns
+        if (availableWidth<=0 || availableHeight<=0) {throw "Width and height must be greater than 0"}
         const builtFlag = createFlag(availableWidth, availableHeight, options)
         process.stdout.write(builtFlag)
     } catch (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,8 @@ const cliOptions = {
     height: {
         type: 'string',
         short: 'h',
-        description: 'The height of the flag, in characters. May not generate the exact specified height',
+        description:
+            'The height of the flag, in characters. May not generate the exact specified height',
         argName: 'int',
     },
     width: {
@@ -219,7 +220,9 @@ function createFlag(availableWidth, availableHeight, options) {
             const color2 = blendColors.getColor(position, options.gradient ? 'gradient' : null)
             color = interpolateColor(color, color2, blendFactor)
         }
-        finishedFlag += chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width ? '\n' : '')
+        finishedFlag +=
+            chalk.hex(color)(CHAR.repeat(availableWidth)) +
+            (options.width ? '\n' : '')
         currLine++
     }
     return finishedFlag.trim()
@@ -231,9 +234,15 @@ function draw() {
         process.stdout.write('\x1b[0;0f\x1b[2J\x1b[?25l')
     }
     try {
-        const availableHeight = options.height ? options.height : process.stdout.rows
-        const availableWidth = options.width ? options.width : process.stdout.columns
-        if (availableWidth<=0 || availableHeight<=0) {throw "Width and height must be greater than 0"}
+        const availableHeight = options.height
+            ? options.height
+            : process.stdout.rows
+        const availableWidth = options.width
+            ? options.width
+            : process.stdout.columns
+        if (availableWidth <= 0 || availableHeight <= 0) {
+            throw new Error('Width and height must be greater than 0')
+        }
         const builtFlag = createFlag(availableWidth, availableHeight, options)
         process.stdout.write(builtFlag)
     } catch (err) {


### PR DESCRIPTION
Added width and height parameters that override the values normally gotten with "process.stdout.rows" and "process.stdout.columns" to allow setting the dimensions of the flag.
Due to the scaling being wonky, the generated height is often different, but idk how to fix that
Also, if a width is specified, a newline character is added to the end of all lines so the flag is displayed correctly

Also changed the help shorthand from "h" to "?" to allow height to have the shorthand "h". This short doesn't work in all shells, however it works in bash and the help is also accessible with --help or not passing in any arguments so I don't think this is an issue.