### PR TITLE
fix weighted flags in help menu

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,13 @@ function help() {
         /// so figure out how many spaces we need to add after the flags name
         const spaces = MINI_FLAG_DISTANCE - name.length
         let flagLine = name.padEnd(name.length + spaces, ' ') /// add calculated spaces...
-        flagLine += flag.stripes.map((color) => chalk.hex(color)(CHAR)).join('') /// ..and then add the miniflag
+        if (flag.weights) {
+            for (let i = 0; i < flag.stripes.length; i++) {
+                flagLine += Array(flag.weights[i]).fill(chalk.hex(flag.stripes[i])(CHAR)).join('')
+            }
+        } else {
+            flagLine += flag.stripes.map((color) => chalk.hex(color)(CHAR)).join('') /// ..and then add the miniflag
+        }
         flagList.push(flagLine)
     }
 


### PR DESCRIPTION
As mentioned in #21, flag weights are ignored in the help menu, meaning e.g. the bi flag is only displayed with 3 stripes instead of five. This fixes that.
One problem is that a lot of the flags get bigger, taking up more space. here's a before and after:
before:
![before](https://github.com/ExperiBass/cli-pride-flags/assets/96649398/4dc76afc-66cd-4c76-b57f-ea8b3abaff0e)
after:
![after](https://github.com/ExperiBass/cli-pride-flags/assets/96649398/dc7e882e-bff8-4842-ad3a-611ec27906a2)