### PR TITLE
add --printname to print name of random flag

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,11 +25,14 @@ Options:
   --blend, -b flag[,factor]   Blend two flags together, with an optional decimal factor
   --character, -c char        Character to use to draw the flag
   --gradient, -g              Make the flag a smooth gradient
-  --height, -h int            The height of the flag, in characters. May not generate the exact specified height
+  --height, -h int            The height of the flag, in characters
   --help, -?                  Display this help text
   --install-completion        Install tabtab shell completion
   --live, -l                  Hold the terminal and redraw the flag upon resize, closing when any key is pressed
+  --printname, -p             Prints name of the randomly chosen flag before the flag. Only works with --random
   --random, -r                Displays a random flag! This ignores any passed flags.
+  --use-flag-height           Uses the number of stripes the flag has as its height. Incompatible with --height
+  --use-flag-width            Uses the number of stripes the flag has as its width. Incompatible with --width
   --vertical, -v              Display the flag, but vertically
   --width, -w int             The width of the flag, in characters
 ```

--- a/src/main.js
+++ b/src/main.js
@@ -45,6 +45,11 @@ const cliOptions = {
         short: 'r',
         description: 'Displays a random flag! This ignores any passed flags.',
     },
+    printname: {
+        type: 'boolean',
+        short: 'p',
+        description: 'Prints name of the randomly chosen flag before the flag. Only works with --random',
+    },
     height: {
         type: 'string',
         short: 'h',
@@ -319,7 +324,11 @@ if (options.help || (!options.random && (CHOSEN_FLAG === undefined || !Object.ke
 let flag
 if (options.random) {
     const flagKeys = Object.keys(flags)
-    flag = flags[flagKeys[randNum(flagKeys.length - 1)]]
+    flagName = flagKeys[randNum(flagKeys.length - 1)]
+    flag = flags[flagName]
+    if (options.printname) {
+        process.stdout.write(flagName + '\n')
+    }
 } else {
     flag = flags[CHOSEN_FLAG]
 }


### PR DESCRIPTION
hi me again with a short one :3
basically i had the random idea to put a random flag at my terminal startup and i wanted to be able to see the name of that flag
so this option does exactly that.
(also updated the readme with this and a couple of older opts where i forgot)