### PR TITLE
stop purely relying on linewrap; always add newlines

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,7 @@ Options:
   --help, -?                  Display this help text
   --install-completion        Install tabtab shell completion
   --live, -l                  Hold the terminal and redraw the flag upon resize, closing when any key is pressed
+  --newline, -n               Prints a newline at the end of each line
   --printname, -p             Prints name of the randomly chosen flag before the flag. Only works with --random
   --random, -r                Displays a random flag! This ignores any passed flags.
   --use-flag-height           Uses the number of stripes the flag has as its height. Incompatible with --height

--- a/src/main.js
+++ b/src/main.js
@@ -234,7 +234,8 @@ function createFlag(availableWidth, availableHeight, options) {
             color = interpolateColor(color, color2, blendFactor)
         }
         finishedFlag +=
-            chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width || options['use-flag-width'] || options.newline ? '\n' : '')
+            chalk.hex(color)(CHAR.repeat(availableWidth)) +
+            (options.width || options['use-flag-width'] || options.newline ? '\n' : '')
     }
     return finishedFlag.trim()
 }

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,11 @@ const cliOptions = {
         description: 'Character to use to draw the flag',
         argName: 'char',
     },
+    newline: {
+        type: 'boolean',
+        short: 'n',
+        description: 'Prints a newline at the end of each line',
+    },
     random: {
         type: 'boolean',
         short: 'r',
@@ -212,7 +217,7 @@ function createFlag(availableWidth, availableHeight, options) {
             }
             finishedFlag += chalk.hex(color)(CHAR)
         }
-        if (options.width || options['use-flag-width']) {
+        if (options.width || options['use-flag-width'] || options.newline) {
             finishedFlag += '\n'
         }
         return finishedFlag.repeat(availableHeight).trim()
@@ -229,7 +234,7 @@ function createFlag(availableWidth, availableHeight, options) {
             color = interpolateColor(color, color2, blendFactor)
         }
         finishedFlag +=
-            chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width || options['use-flag-width'] ? '\n' : '')
+            chalk.hex(color)(CHAR.repeat(availableWidth)) + (options.width || options['use-flag-width'] || options.newline ? '\n' : '')
     }
     return finishedFlag.trim()
 }


### PR DESCRIPTION
basically just removes the checks for width||use-flag-width being set
this allows you to resize your terminal w/o flags decomposing